### PR TITLE
[Backport to 2.15.x issue 79 ]gui fix at Geometry definition is not selected on Edit Layer Page for

### DIFF
--- a/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/core/longitudelatitude/LongLatGeometryGenerationStrategy.java
+++ b/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/core/longitudelatitude/LongLatGeometryGenerationStrategy.java
@@ -53,11 +53,11 @@ public class LongLatGeometryGenerationStrategy
 
     private static final long serialVersionUID = 1L;
 
-    static final String NAME = "longLat";
-    static final String LONGITUDE_ATTRIBUTE_NAME = "longitudeAttributeName";
-    static final String LATITUDE_ATTRIBUTE_NAME = "latitudeAttributeName";
-    static final String GEOMETRY_ATTRIBUTE_NAME = "geometryAttributeName";
-    static final String GEOMETRY_CRS = "geometryCRS";
+    public static final String NAME = "longLat";
+    public static final String LONGITUDE_ATTRIBUTE_NAME = "longitudeAttributeName";
+    public static final String LATITUDE_ATTRIBUTE_NAME = "latitudeAttributeName";
+    public static final String GEOMETRY_ATTRIBUTE_NAME = "geometryAttributeName";
+    public static final String GEOMETRY_CRS = "geometryCRS";
 
     private final transient Map<Name, SimpleFeatureType> cache = new HashMap<>();
     private final GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory();

--- a/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/web/GeneratedGeometryConfigurationPanel.java
+++ b/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/web/GeneratedGeometryConfigurationPanel.java
@@ -34,6 +34,7 @@ import org.apache.wicket.model.StringResourceModel;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.ResourcePool;
+import org.geoserver.generatedgeometries.core.GeometryGenerationStrategy;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.data.resource.BasicResourceConfig;
@@ -123,10 +124,19 @@ public class GeneratedGeometryConfigurationPanel extends ResourceConfigurationPa
         methodologyConfiguration.setOutputMarkupId(true);
         content.add(methodologyConfiguration);
 
+        Optional<String> modelStrategy =
+                GeometryGenerationStrategy.getStrategyName(((FeatureTypeInfo) model.getObject()));
+
         for (GeometryGenerationStrategyUIGenerator ggsp : strategies) {
             Component configuration = ggsp.createUI("configuration", model);
             componentMap.put(ggsp.getName(), configuration);
-            configuration.setVisible(false);
+            // check if this is the strategy attached with model
+            boolean isVisible =
+                    (modelStrategy.isPresent()
+                            && ggsp.getName().equalsIgnoreCase(modelStrategy.get()));
+            configuration.setVisible(isVisible);
+            // check if this is the strategy attached with model then set this as selection
+            if (isVisible) methodologyDropDown.setModelObject(ggsp);
         }
 
         methodologyConfiguration.add(
@@ -158,6 +168,7 @@ public class GeneratedGeometryConfigurationPanel extends ResourceConfigurationPa
             isGeometryCreated =
                     ((FeatureTypeInfo) model.getObject()).getFeatureType().getGeometryDescriptor()
                             != null;
+
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/web/GeometryGenerationStrategyUIGenerator.java
+++ b/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/web/GeometryGenerationStrategyUIGenerator.java
@@ -5,6 +5,7 @@
 
 package org.geoserver.generatedgeometries.web;
 
+import java.io.Serializable;
 import org.apache.wicket.Component;
 import org.apache.wicket.model.IModel;
 import org.geoserver.catalog.FeatureTypeInfo;
@@ -14,7 +15,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
  * org.geoserver.generatedgeometries.core.GeometryGenerationStrategy} implementation. Should be
  * instantiated as Spring bean.
  */
-public interface GeometryGenerationStrategyUIGenerator {
+public interface GeometryGenerationStrategyUIGenerator extends Serializable {
 
     /**
      * The name of the UI that can be used for identifying it. Usually it is the same as name of

--- a/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/web/longitudelatitude/LongLatGeometryStrategyUIGenerator.java
+++ b/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/web/longitudelatitude/LongLatGeometryStrategyUIGenerator.java
@@ -32,9 +32,7 @@ public class LongLatGeometryStrategyUIGenerator
 
     @Override
     public Component createUI(String id, IModel model) {
-        if (longLatConfigPanel == null) {
-            longLatConfigPanel = new LongLatGeometryConfigurationPanel(id, model);
-        }
+        longLatConfigPanel = new LongLatGeometryConfigurationPanel(id, model);
         return longLatConfigPanel;
     }
 

--- a/src/community/generated-geometries/src/test/java/org/geoserver/generatedgeometries/web/GeneratedGeometryConfigurationPanelTest.java
+++ b/src/community/generated-geometries/src/test/java/org/geoserver/generatedgeometries/web/GeneratedGeometryConfigurationPanelTest.java
@@ -11,6 +11,7 @@ import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTe
 import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.LONG_LAT_NO_GEOM_ON_THE_FLY_LAYER;
 import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.LONG_LAT_NO_GEOM_ON_THE_FLY_QNAME;
 import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.LONG_LAT_QNAME;
+import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.enableGeometryGenerationStrategy;
 import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.filenameOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -27,6 +28,7 @@ import org.geoserver.catalog.FeatureTypeInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.ResourcePool;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.generatedgeometries.core.longitudelatitude.LongLatGeometryGenerationStrategy;
 import org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData;
 import org.geoserver.generatedgeometries.dummy.DummyGGStrategy;
 import org.geoserver.web.GeoServerApplication;
@@ -154,5 +156,23 @@ public class GeneratedGeometryConfigurationPanelTest extends GeoServerWicketTest
         // then
         DummyGGStrategy strategy = (DummyGGStrategy) applicationContext.getBean("dummyStrategy");
         assertTrue(strategy.configured);
+    }
+
+    @Test
+    public void testThatStrategyfromModelMetadataIsSelected() throws Exception {
+
+        Catalog catalog = getGeoServerApplication().getCatalog();
+        FeatureTypeInfo featureTypeInfo = getFeatureTypeInfo(LONG_LAT_QNAME);
+        // enable latlong extension on this feature type
+        enableGeometryGenerationStrategy(catalog, featureTypeInfo);
+        LayerInfo layerInfo = catalog.getLayerByName(getLayerId(LONG_LAT_QNAME));
+        login();
+
+        // open layer info page
+        tester.startPage(new ResourceConfigurationPage(layerInfo, true));
+
+        DropDownChoice<GeometryGenerationStrategyUIGenerator> dropDown = getStrategyDropDown();
+        GeometryGenerationStrategyUIGenerator selectedGeometryGenGUI = dropDown.getModelObject();
+        assertEquals(selectedGeometryGenGUI.getName(), LongLatGeometryGenerationStrategy.NAME);
     }
 }

--- a/src/main/src/main/java/org/geoserver/catalog/RetypeFeatureTypeCallback.java
+++ b/src/main/src/main/java/org/geoserver/catalog/RetypeFeatureTypeCallback.java
@@ -1,6 +1,6 @@
-/*  (c) 2019 Open Source Geospatial Foundation - all rights reserved
- *  This code is licensed under the GPL 2.0 license, available at the root
- *  application directory.
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
  */
 
 package org.geoserver.catalog;


### PR DESCRIPTION
Backport of Layers using Generated Geometries extension issue  #https://github.com/geosolutions-it/C105-2018-EMSA-VDS/issues/79