### PR TITLE
Generated geometries don't set the native SRS issue 89

### DIFF
--- a/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/core/GeneratedGeometryBoundsFinder.java
+++ b/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/core/GeneratedGeometryBoundsFinder.java
@@ -1,0 +1,37 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.generatedgeometries.core;
+
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.opengis.feature.Feature;
+import org.opengis.feature.FeatureVisitor;
+import org.opengis.geometry.BoundingBox;
+
+public class GeneratedGeometryBoundsFinder implements FeatureVisitor {
+
+    private FeatureTypeInfo featureTypeInfo;
+    private BoundingBox bbox = null;
+
+    public GeneratedGeometryBoundsFinder(FeatureTypeInfo featureTypeInfo) {
+        this.featureTypeInfo = featureTypeInfo;
+    }
+
+    @Override
+    public void visit(Feature feature) {
+
+        if (bbox == null) bbox = feature.getBounds();
+        else bbox.include(feature.getBounds());
+    }
+
+    public ReferencedEnvelope getBounds() {        
+        ReferencedEnvelope refEnv = new ReferencedEnvelope(featureTypeInfo.getCRS());
+        
+        if(bbox == null) return refEnv;
+        
+        refEnv.setBounds(bbox);        
+        return refEnv;
+    }
+}

--- a/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/core/longitudelatitude/LongLatGeometryGenerationStrategy.java
+++ b/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/core/longitudelatitude/LongLatGeometryGenerationStrategy.java
@@ -53,7 +53,7 @@ public class LongLatGeometryGenerationStrategy
 
     private static final long serialVersionUID = 1L;
 
-    static final String NAME = "longLat";
+    public static final String NAME = "longLat";
     static final String LONGITUDE_ATTRIBUTE_NAME = "longitudeAttributeName";
     static final String LATITUDE_ATTRIBUTE_NAME = "latitudeAttributeName";
     static final String GEOMETRY_ATTRIBUTE_NAME = "geometryAttributeName";
@@ -109,6 +109,7 @@ public class LongLatGeometryGenerationStrategy
     @Override
     public void configure(FeatureTypeInfo info) {
         info.setSRS(CRS.toSRS(getLongLatConfiguration(info).crs));
+        info.setNativeCRS(getLongLatConfiguration(info).crs);
         featureTypeInfos.add(info.getId());
     }
 

--- a/src/community/generated-geometries/src/test/java/org/geoserver/generatedgeometries/core/GeometryGenerationFeatureSourceTest.java
+++ b/src/community/generated-geometries/src/test/java/org/geoserver/generatedgeometries/core/GeometryGenerationFeatureSourceTest.java
@@ -5,25 +5,39 @@
 
 package org.geoserver.generatedgeometries.core;
 
+import static java.util.Collections.emptyMap;
+import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.LONG_LAT_LAYER;
+import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.LONG_LAT_NO_GEOM_ON_THE_FLY_LAYER;
+import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.LONG_LAT_NO_GEOM_ON_THE_FLY_QNAME;
+import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.LONG_LAT_QNAME;
+import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.enableGeometryGenerationStrategy;
+import static org.geoserver.generatedgeometries.core.longitudelatitude.LongLatTestData.filenameOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import java.io.IOException;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.GeoServerSystemTestSupport;
 import org.geotools.data.Query;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.hamcrest.CoreMatchers;
+import org.junit.Before;
 import org.junit.Test;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 
-public class GeometryGenerationFeatureSourceTest {
+public class GeometryGenerationFeatureSourceTest extends GeoServerSystemTestSupport {
 
     private FeatureTypeInfo featureTypeInfo = mock(FeatureTypeInfo.class);
     private SimpleFeatureSource delegate = mock(SimpleFeatureSource.class);
@@ -31,6 +45,35 @@ public class GeometryGenerationFeatureSourceTest {
 
     private GeometryGenerationFeatureSource featureSource =
             new GeometryGenerationFeatureSource(featureTypeInfo, delegate, strategy);
+
+    @Before
+    public void before() throws Exception {
+        getGeoServer().reload();
+    }
+
+    @Override
+    protected void onSetUp(SystemTestData testData) throws Exception {
+        super.onSetUp(testData);
+        setupBasicLayer(testData);
+        setupComplexLayer(testData);
+    }
+
+    private void setupBasicLayer(SystemTestData testData) throws IOException {
+        testData.addVectorLayer(
+                LONG_LAT_NO_GEOM_ON_THE_FLY_QNAME,
+                emptyMap(),
+                filenameOf(LONG_LAT_NO_GEOM_ON_THE_FLY_LAYER),
+                getClass(),
+                getCatalog());
+    }
+
+    private void setupComplexLayer(SystemTestData testData) throws IOException {
+        Catalog catalog = getCatalog();
+        testData.addVectorLayer(
+                LONG_LAT_QNAME, emptyMap(), filenameOf(LONG_LAT_LAYER), getClass(), catalog);
+        FeatureTypeInfo featureTypeInfo = getFeatureTypeInfo(LONG_LAT_QNAME);
+        enableGeometryGenerationStrategy(catalog, featureTypeInfo);
+    }
 
     @Test
     public void testThatDefinesSchemaAtFirstUse() {
@@ -122,5 +165,32 @@ public class GeometryGenerationFeatureSourceTest {
 
         // then
         assertThat(count, is(17));
+    }
+
+    @Test
+    public void testThatBoundingBoxisCalculatedFromData() throws IOException {
+
+        // when
+        SimpleFeatureSource featureSource = getFeatureSource(LONG_LAT_QNAME);
+
+        ReferencedEnvelope bounds = featureSource.getBounds();
+
+        // then
+        assertNotNull(bounds);
+
+        assertTrue(bounds.getMaxX() == 1.0);
+        assertTrue(bounds.getMaxY() == 1.0);
+        assertTrue(bounds.getMinX() == -1.0);
+        assertTrue(bounds.getMinY() == -1.0);
+
+        ReferencedEnvelope boundsQuery = featureSource.getBounds(Query.ALL);
+
+        // then
+        assertNotNull(boundsQuery);
+
+        assertTrue(boundsQuery.getMaxX() == 1.0);
+        assertTrue(boundsQuery.getMaxY() == 1.0);
+        assertTrue(boundsQuery.getMinX() == -1.0);
+        assertTrue(boundsQuery.getMinY() == -1.0);
     }
 }

--- a/src/community/generated-geometries/src/test/resources/org/geoserver/generatedgeometries/core/LongLatBasicLayer.properties
+++ b/src/community/generated-geometries/src/test/resources/org/geoserver/generatedgeometries/core/LongLatBasicLayer.properties
@@ -1,0 +1,2 @@
+_=id:java.lang.Integer,lon:java.lang.Double,lat:java.lang.Double,data:java.lang.String
+feature.0=0|0|0|data

--- a/src/community/generated-geometries/src/test/resources/org/geoserver/generatedgeometries/core/LongLatLayer.properties
+++ b/src/community/generated-geometries/src/test/resources/org/geoserver/generatedgeometries/core/LongLatLayer.properties
@@ -1,0 +1,6 @@
+_=id:java.lang.Integer,lon:java.lang.Double,lat:java.lang.Double,data:java.lang.String
+feature.0=0|0|0|d1
+feature.1=1|-1.0|0|d2
+feature.2=2|1.0|0|d3
+feature.3=3|-1.0|-1.0|d4
+feature.4=4|0|1.0|d5


### PR DESCRIPTION
-native srid is set
-bounds are calculated
issue described at https://github.com/geosolutions-it/C105-2018-EMSA-VDS/issues/89
