### PR TITLE
retaining hints ofsource query

### DIFF
--- a/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/core/longitudelatitude/LongLatGeometryGenerationStrategy.java
+++ b/src/community/generated-geometries/src/main/java/org/geoserver/generatedgeometries/core/longitudelatitude/LongLatGeometryGenerationStrategy.java
@@ -230,6 +230,7 @@ public class LongLatGeometryGenerationStrategy
     @Override
     public Query convertQuery(FeatureTypeInfo info, Query query) {
         Query q = new Query();
+        q.setHints(query.getHints());        
         q.setFilter(convertFilter(info, query.getFilter()));
         LongLatConfiguration configuration = getLongLatConfiguration(info);
         List<String> properties = new ArrayList<>();


### PR DESCRIPTION
when re-creating the query, hints were not copied due to which `viewparams `never reached SQL views