### PR TITLE
[2.16.x backport][GEOS-9496] Inconsistency between security tab rules…

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/security/AccessDataRuleInfoManager.java
+++ b/src/web/core/src/main/java/org/geoserver/web/security/AccessDataRuleInfoManager.java
@@ -70,14 +70,16 @@ public class AccessDataRuleInfoManager {
 
     public List<DataAccessRule> getRules() {
         DataAccessRuleDAO dao = getSecurityManager().getDataAccessRuleDAO();
-        dao.reload();
         return dao.getRules();
     }
 
     public Set<DataAccessRule> getWorkspaceDataAccessRules(String workspaceName) {
         return getRules()
                 .stream()
-                .filter(r -> r.getRoot().equalsIgnoreCase(workspaceName))
+                .filter(
+                        r ->
+                                r.getRoot().equalsIgnoreCase(workspaceName)
+                                        && r.getLayer().equals("*"))
                 .collect(Collectors.toSet());
     }
 

--- a/src/web/core/src/test/java/org/geoserver/web/security/AccessDataRuleInfoManagerTest.java
+++ b/src/web/core/src/test/java/org/geoserver/web/security/AccessDataRuleInfoManagerTest.java
@@ -61,7 +61,7 @@ public class AccessDataRuleInfoManagerTest extends GeoServerWicketTestSupport {
                 ruleInfoMan.mapFrom(
                         rulesInfo, availableRoles, ws.getName(), layerInfo.getName(), false);
         ruleInfoMan.saveRules(dataRules, news);
-        assertTrue(ruleInfoMan.getResourceRule(ws.getName(), ws).size() == 1);
+        assertTrue(ruleInfoMan.getResourceRule(ws.getName(), layerInfo).size() == 1);
         cleanRules(ws.getName(), layerInfo);
     }
 


### PR DESCRIPTION
… and the usual data rules page